### PR TITLE
Change path to android_prepare.sh

### DIFF
--- a/scripts/travis-ci/android_prepare.sh
+++ b/scripts/travis-ci/android_prepare.sh
@@ -3,7 +3,7 @@
 
 set -e
 
-source /scripts/travis-ci/android_common.source
+source ~/ros2_android/scripts/travis-ci/android_common.source
 
 if [ $DEBUG -eq 1 ]
 then

--- a/scripts/travis-ci/android_prepare.sh
+++ b/scripts/travis-ci/android_prepare.sh
@@ -3,7 +3,7 @@
 
 set -e
 
-source android_common.source
+source /scripts/travis-ci/android_common.source
 
 if [ $DEBUG -eq 1 ]
 then


### PR DESCRIPTION
Travis fails because it can't find `android_prepare.sh`. [See here](https://travis-ci.org/ros2java-alfred/ros2_android#L936).